### PR TITLE
Extras are not injected into http location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # mesudip/python-nginx:alpine is merge of official python and nginx images.
 FROM mesudip/python-nginx:alpine
+
+RUN pip install --upgrade pip
+
 HEALTHCHECK --interval=10s --timeout=2s --start-period=10s --retries=3 CMD pgrep nginx &&  pgrep python3 >> /dev/null  || exit 1
 VOLUME  ["/etc/nginx/dhparam", "/tmp/acme-challenges/","/etc/nginx/conf.d","/etc/nginx/ssl"]
 CMD ["sh","-e" ,"/docker-entrypoint.sh"]

--- a/vhosts_template/default.conf.jinja2
+++ b/vhosts_template/default.conf.jinja2
@@ -53,8 +53,8 @@ server{
         listen {{ server.port }} {{ server.extras.default_server }};
         server_name {{ server.hostname }};{% if server.is_redirect %}
         return 301 {{  "https" if server.secured else "http" }}://{{ server.full_redirect.hostname }}$request_uri;{% else %}{% for location in server.locations.values() %}
-        location {{ location.name }} { {% if location.upstream %}{% for injection in location.extras.injected %}
-            {{ injection }};{% endfor %}
+        location {{ location.name }} { {% for injection in location.extras.injected %}
+            {{ injection }};{% endfor %} {% if location.upstream %}
             proxy_pass {{ location.container.scheme }}://{{ location.upstream }}{{location.container.path}};{% else %}
             proxy_pass {{location.container.scheme }}://{{ location.container.address }}:{{ location.container.port }}{{ location.container.path }};{% endif %}{% if location.name != '/' %}
             proxy_redirect $scheme://$http_host{{ location.container.path if location.container.path else '/' }} $scheme://$http_host{{location.name}};{% endif %}  {% if location.websocket and location.http %}


### PR DESCRIPTION
Fixed issue with http, where extras were not being injected into the config correctly.
The expansion of the extras was happening within the location.upstream if rather then outside it as happens in the secured block.

Added a pip upgrade to the docker file so it wont try and fail to build the encryption wheel and will instead download it. Without this I was unable to build the docker image.